### PR TITLE
update template to show current best offer and winning bid

### DIFF
--- a/auctions/templates/auctions/listing_detail.html
+++ b/auctions/templates/auctions/listing_detail.html
@@ -28,9 +28,9 @@
         <tbody>
             {% for bid in bids %}
                 <tr>
-                    <td>KES. {{ bid.amount }}</td>
+                    <td>KES. {{ bid.amount|floatformat:2 }}</td>
                     <td>{{ bid.user.username }}</td>
-                    <td>{{ bid.timestamp }}</td>
+                    <td>{{ bid.timestamp|date:"l, d M Y \a\t P" }}</td>
                     <td>
                         {% if bid.is_below_base_price %}
                             <span class="status-below-base">Below Base Price</span>
@@ -51,7 +51,7 @@
         <h2>Current Best Offer</h2>
         {% with current_best_offer=listing.winning_bid %}
             {% if current_best_offer %}
-                <p>KES. {{ current_best_offer.amount }} by {{ current_best_offer.user.username }} on {{ current_best_offer.timestamp }}</p>
+                <p>KES. {{ current_best_offer.amount|floatformat:2 }} by {{ current_best_offer.user.username }} on {{ current_best_offer.timestamp|date:"l, d M Y \a\t P" }}</p>
             {% else %}
                 <p>No bids have been placed yet.</p>
             {% endif %}
@@ -60,7 +60,7 @@
         <h2>Winning Bid</h2>
         {% with winning_bid=listing.winning_bid %}
             {% if winning_bid %}
-                <p>KES. {{ winning_bid.amount }} by {{ winning_bid.user.username }} on {{ winning_bid.timestamp }}</p>
+                <p>KES. {{ winning_bid.amount|floatformat:2 }} by {{ winning_bid.user.username }} on {{ winning_bid.timestamp|date:"l, d M Y \a\t P" }}</p>
             {% else %}
                 <p>No winning bid was placed for this auction.</p>
             {% endif %}

--- a/auctions/templates/auctions/listing_detail.html
+++ b/auctions/templates/auctions/listing_detail.html
@@ -47,11 +47,24 @@
         </tbody>
     </table>
 
-    <h2>Current Best Offer</h2>
-    {% if current_best_offer %}
-        <p>KES. {{ current_best_offer.amount }} by {{ current_best_offer.user.username }}</p>
-    {% else %}
-        <p>There is no current best offer.</p>
+    {% if listing.auction.status == 'active' %}
+        <h2>Current Best Offer</h2>
+        {% with current_best_offer=listing.winning_bid %}
+            {% if current_best_offer %}
+                <p>KES. {{ current_best_offer.amount }} by {{ current_best_offer.user.username }} on {{ current_best_offer.timestamp }}</p>
+            {% else %}
+                <p>No bids have been placed yet.</p>
+            {% endif %}
+        {% endwith %}
+    {% elif listing.auction.status == 'ended' %}
+        <h2>Winning Bid</h2>
+        {% with winning_bid=listing.winning_bid %}
+            {% if winning_bid %}
+                <p>KES. {{ winning_bid.amount }} by {{ winning_bid.user.username }} on {{ winning_bid.timestamp }}</p>
+            {% else %}
+                <p>No winning bid was placed for this auction.</p>
+            {% endif %}
+        {% endwith %}
     {% endif %}
 
     <!-- Navigation Links -->


### PR DESCRIPTION
## Summary by Sourcery

Update the listing detail template to display the current best offer for active auctions and the winning bid for ended auctions, including relevant details such as amount, user, and timestamp.

Enhancements:
- Display the current best offer for active auctions, including the amount, user, and timestamp.
- Display the winning bid for ended auctions, including the amount, user, and timestamp.
- Show a message when no bids have been placed for active auctions.
- Show a message when no winning bid was placed for ended auctions.